### PR TITLE
Fix NeoMake JavaScript makers config override

### DIFF
--- a/after/ftplugin/javascript.vim
+++ b/after/ftplugin/javascript.vim
@@ -10,6 +10,6 @@ let g:neomake_javascript_tss_maker = {
             \ '%C%\s%\+%m'
         \ }
 
-let g:neomake_javascript_enabled_makers = ['jshint', 'tss']
+let g:neomake_javascript_enabled_makers = get(g:, 'neomake_javascript_enabled_makers', []) + ['tss']
 
 call tss#init()


### PR DESCRIPTION
If `g:neomake_javascript_enabled_makers` already exists in the configuration, concatenate `['tss']` to the existing list, otherwise, set it to an empty array and then concatenate that with `['tss']`. Fixes #3.